### PR TITLE
Added mapping of dated out-of-copyright licences

### DIFF
--- a/uniform-maps/LicenseURIMap.xml
+++ b/uniform-maps/LicenseURIMap.xml
@@ -869,7 +869,8 @@
 	</mapping>
 	<mapping>
 		<normalizedValue value="http://www.europeana.eu/rights/out-of-copyright-non-commercial/" />
-		<variant value="https://www.europeana.eu/rights/out-of-copyright-non-commercial/" />
+		<!-- e.g. http://www.europeana.eu/rights/out-of-copyright-non-commercial/2029-08-04 -->
+		<variant value="https?://www.europeana.eu/rights/out-of-copyright-non-commercial/.*" isRegExp="true" />
 	</mapping>
 
 </mappings>


### PR DESCRIPTION
Occurring in Europeana with "rightURIs" such as http://www.europeana.eu/rights/out-of-copyright-non-commercial/2029-08-04. Now leading to 'unspecified' licence info, see e.g. [this record](http://alpha-vlo.clarin.eu/vlo/record?docId=europeana_58_aggregation_47_europeana_47_9200332_47_BibliographicResource_3000113551160).