### PR TITLE
Fixed typo in facetConcepts.xml for keywords facet

### DIFF
--- a/mapping/facetConcepts.xml
+++ b/mapping/facetConcepts.xml
@@ -675,7 +675,7 @@
 		<concept>http://hdl.handle.net/11459/CCR_C-5436_6ab57c2c-5f8d-3561-6db6-d75da23d2637</concept>
                 <!-- concept 'keyword' -->
                 <concept>http://www.isocat.org/datcat/DC-278</concept>
-		<concept>http://hdl.handle.net/11459/CCR_C-278_336dd81a-626b-713e-c74a-34fa2ca26a71"</concept>
+		<concept>http://hdl.handle.net/11459/CCR_C-278_336dd81a-626b-713e-c74a-34fa2ca26a71</concept>
 		<!-- not an official ISOcat PID - added to support LrtInventoryResource, should be removed in the future -->
 		<pattern>/cmd:CMD/cmd:Components/cmdp:mods/cmdp:classification/text()</pattern>
 


### PR DESCRIPTION
The concept link `http://hdl.handle.net/11459/CCR_C-278_336dd81a-626b-713e-c74a-34fa2ca26a71` was erroneously specified with a double quote at the end before the closing tag.

Found thanks to  https://github.com/clarin-eric/metadata-curation/issues/11.